### PR TITLE
Fix dowloaded file cannot be read by other app

### DIFF
--- a/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/ApplozicDocumentView.java
+++ b/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/ApplozicDocumentView.java
@@ -292,6 +292,7 @@ public class ApplozicDocumentView {
                     Intent intent = new Intent();
                     intent.setAction(Intent.ACTION_VIEW);
                     intent.setDataAndType(uri, mimeType);
+                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                     if (intent.resolveActivity(context.getPackageManager()) != null) {
                         context.startActivity(intent);
                     } else {


### PR DESCRIPTION
Issue:
When i received a PDF file, i downloaded it and clicked on the file icon after the download procedure completed in one chat room. But the file cannot be accessed by any one of PDF reader apps due to missing read permission.