### PR TITLE
Remove unused & invalid `dimen` Strings file entries

### DIFF
--- a/mobicomkitui/src/main/res/values/strings.xml
+++ b/mobicomkitui/src/main/res/values/strings.xml
@@ -71,9 +71,6 @@
         <item>#2093cd</item>
         <item>#ad62a7</item>
     </array>
-    <dimen name="tile_letter_font_size">250dp</dimen>
-    <!-- The deafult tile size -->
-    <dimen name="letter_tile_size">64dp</dimen>
 
     <string name="contact_permission">Contact permission are needed to access</string>
     <string name="storage_permission">Storage permission are needed to access</string>

--- a/mobicomkitui/src/main/res/values/strings.xml
+++ b/mobicomkitui/src/main/res/values/strings.xml
@@ -61,16 +61,6 @@
     -->
     <string name="search_match_other">Matches Other Field</string>
     <string name="invite">Invite your friends</string>
-    <array name="alphabet_color">
-        <item>#f16364</item>
-        <item>#f58559</item>
-        <item>#f9a43e</item>
-        <item>#e4c62e</item>
-        <item>#67bf74</item>
-        <item>#59a2be</item>
-        <item>#2093cd</item>
-        <item>#ad62a7</item>
-    </array>
 
     <string name="contact_permission">Contact permission are needed to access</string>
     <string name="storage_permission">Storage permission are needed to access</string>


### PR DESCRIPTION
## Summary
Cleaning up some unused & technically invalid entries from the `strings.xml` file.

## Motivation
Cleanup & preventing potential issues or confusion with translation tools in the future. `dimen` entries are not valid entries in `strings.xml` files as per the [documentation](https://developer.android.com/guide/topics/resources/string-resource) (only `string`, `string-array` and `plurals` are valid), they should instead be in a `dimens.xml` file. I considered moving these entries into the existing dimens file, but I couldn't find any reference to them in the project anywhere, so I guess they are not needed and I just removed them instead.

## Testing
I did not test the changes, I only used the GitHub search feature to check if they are still referenced and found 0 results both in issues and code, thus I believe this will not have any negative impact on the project.
